### PR TITLE
Blank node identifiers should start with _:

### DIFF
--- a/src/jsonld-vis.js
+++ b/src/jsonld-vis.js
@@ -66,7 +66,7 @@
         tree.isIdNode = true;
         tree.isBlankNode = true;
         // random id, can replace with actual uuid generator if needed
-        tree.name = '_' + Math.random().toString(10).slice(-7);
+        tree.name = '_:' + Math.random().toString(10).slice(-7);
       }
 
       var children = [];

--- a/src/jsonld-vis.js
+++ b/src/jsonld-vis.js
@@ -66,7 +66,7 @@
         tree.isIdNode = true;
         tree.isBlankNode = true;
         // random id, can replace with actual uuid generator if needed
-        tree.name = '_:' + Math.random().toString(10).slice(-7);
+        tree.name = '_:b' + Math.random().toString(10).slice(-7);
       }
 
       var children = [];


### PR DESCRIPTION
Hello - section 7 of the json-ld spec says that blank node identifiers should start with "_:" rather than just "_"
